### PR TITLE
enhance:  Remove some features that are not used frequently to reduce startup time.

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -4,7 +4,7 @@ tnoremap <Esc> <C-\><C-n>
 " set path+=**
 
 " set clipboard shared with other nvim process
-set clipboard=unnamedplus
+" set clipboard=unnamedplus
 " set file encoding
 " ref: https://ppt.cc/PMkV
 set fileencodings=utf8,big5
@@ -42,7 +42,7 @@ nnoremap <C-[> <C-T>
 " ===== Plugin =====
 call plug#begin('~/.vim/plugged')
     "
-    Plug 'mhinz/vim-startify'
+    " Plug 'mhinz/vim-startify'
     " For project
     Plug 'ilyachur/cmake4vim'
 


### PR DESCRIPTION
### Description
The start up time in my laptop for work had been to 5 seconds up. It's too long...
So I remove some plugin/setting here.
- vim-startify (start screen plugin) accounts upon to 3 seconds.  
- clipboard=unnamedplus (clipboard sharing across nvim instances) accounts for 1 second.
After remove them, my nvim startup time returns to under 1 second which is acceptable time. 